### PR TITLE
Add safe uninstaller that actually preserves user work

### DIFF
--- a/cc_sessions/uninstall.py
+++ b/cc_sessions/uninstall.py
@@ -1,0 +1,775 @@
+#!/usr/bin/env python3
+"""
+Claude Code Sessions Framework - Cross-Platform Safe Uninstaller
+
+Complete uninstallation system for the Claude Code Sessions framework with native
+Windows, macOS, Linux, and WSL support. Handles platform-specific path handling,
+backup creation, and safe removal with user data preservation.
+
+Key Features:
+    - Cross-platform compatibility (Windows, macOS, Linux, WSL)
+    - Comprehensive backup system with compression
+    - Restore functionality from backups
+    - Interactive menu with multiple uninstall modes
+    - Dry-run mode for safety testing
+    - Selective component removal
+    - Preservation of user tasks and work logs
+
+Platform Support:
+    - Windows 10/11 (Command Prompt, PowerShell, Git Bash)
+    - macOS (Bash, Zsh)
+    - Linux distributions (Bash, other shells)
+    - WSL (Windows Subsystem for Linux)
+
+Backup System:
+    - Creates compressed backups (.tar.gz) with metadata
+    - Includes all cc-sessions files and configuration
+    - Stores installation metadata for restore operations
+    - Preserves settings.json hook entries for restoration
+
+Safety Features:
+    - Dry-run mode shows what would be removed
+    - Multiple confirmation prompts
+    - Atomic operations (all-or-nothing)
+    - User data preservation (tasks, work logs)
+    - Backup validation before removal
+
+See Also:
+    - uninstall.js: Node.js uninstaller wrapper with same functionality
+    - install.py: Original installer this uninstaller reverses
+"""
+
+import os
+import sys
+import json
+import shutil
+import stat
+import tarfile
+import subprocess
+from pathlib import Path
+from datetime import datetime
+from typing import Dict, Any, Optional, List, Tuple
+
+# Colors for terminal output
+class Colors:
+    RESET = '\033[0m'
+    BRIGHT = '\033[1m'
+    DIM = '\033[2m'
+    RED = '\033[31m'
+    GREEN = '\033[32m'
+    YELLOW = '\033[33m'
+    BLUE = '\033[34m'
+    MAGENTA = '\033[35m'
+    CYAN = '\033[36m'
+    WHITE = '\033[37m'
+    BGRED = '\033[41m'
+    BGGREEN = '\033[42m'
+    BGYELLOW = '\033[43m'
+
+def color(text: str, color_code: str) -> str:
+    """Colorize text for terminal output"""
+    return f"{color_code}{text}{Colors.RESET}"
+
+def ask_yes_no(prompt: str, default: bool = True) -> bool:
+    """
+    Ask a yes/no question with a default option
+
+    Args:
+        prompt: The question to ask
+        default: True for yes default (Y/n), False for no default (y/N)
+
+    Returns:
+        bool: True for yes, False for no
+    """
+    if default:
+        suffix = " (Y/n): "
+    else:
+        suffix = " (y/N): "
+
+    while True:
+        response = input(color(prompt + suffix, Colors.CYAN)).strip().lower()
+
+        if response == "":
+            return default
+        elif response in ["y", "yes"]:
+            return True
+        elif response in ["n", "no"]:
+            return False
+        else:
+            print(color("  Please enter y, n, yes, no, or press Enter for default", Colors.YELLOW))
+
+def detect_platform() -> str:
+    """
+    Detect the current platform with special handling for WSL
+
+    Returns:
+        str: 'windows', 'macos', 'linux', or 'wsl'
+    """
+    if os.name == 'nt':
+        return 'windows'
+    elif sys.platform == 'darwin':
+        return 'macos'
+    else:
+        # Check for WSL
+        if os.path.exists('/proc/sys/fs/binfmt_misc/WSLInterop'):
+            return 'wsl'
+        return 'linux'
+
+def get_package_dir() -> Path:
+    """Get the directory where the package is installed"""
+    import cc_sessions
+    return Path(cc_sessions.__file__).parent
+
+class SessionsUninstaller:
+    """
+    Main uninstaller class for cc-sessions framework
+
+    Handles detection, backup, and removal of all cc-sessions components
+    across different platforms while preserving user data.
+    """
+
+    def __init__(self):
+        """Initialize the uninstaller with platform detection and project discovery"""
+        self.platform = detect_platform()
+        self.package_dir = get_package_dir()
+        self.project_root = self.detect_project_directory()
+        self.installation = self.detect_installation()
+
+    def detect_project_directory(self) -> Path:
+        """Detect the correct project directory when running from pip/pipx"""
+        current_dir = Path.cwd()
+
+        # If running from site-packages or pipx environment
+        if 'site-packages' in str(current_dir) or '.local/pipx' in str(current_dir):
+            print(color("⚠️  Running from package directory, not project directory.", Colors.YELLOW))
+            print()
+            project_path = input("Enter the path to your project directory (or press Enter for current directory): ")
+            if project_path:
+                return Path(project_path).resolve()
+            else:
+                return Path.cwd()
+
+        return current_dir
+
+    def detect_installation(self) -> Optional[Dict[str, Any]]:
+        """
+        Detect if cc-sessions is installed in this project
+
+        Returns:
+            Optional[Dict]: Installation details or None if not installed
+        """
+        config_file = self.project_root / "sessions/sessions-config.json"
+        if not config_file.exists():
+            return None
+
+        try:
+            with open(config_file) as f:
+                config = json.load(f)
+
+            # Collect installation details
+            installation = {
+                "config_file": config_file,
+                "config": config,
+                "version": config.get("version", "unknown"),
+                "platform": self.platform,
+                "components": self._scan_components(),
+                "global_commands": self._scan_global_commands(),
+                "settings_hooks": self._scan_settings_hooks()
+            }
+
+            return installation
+        except Exception as e:
+            print(color(f"⚠️  Error reading configuration: {e}", Colors.YELLOW))
+            return None
+
+    def _scan_components(self) -> Dict[str, List[str]]:
+        """
+        Scan for installed cc-sessions components
+
+        Returns:
+            Dict[str, List[str]]: Components organized by category
+        """
+        components = {
+            "hooks": [],
+            "agents": [],
+            "commands": [],
+            "protocols": [],
+            "templates": [],
+            "knowledge": [],
+            "state": []
+        }
+
+        # Scan hooks
+        hooks_dir = self.project_root / ".claude/hooks"
+        if hooks_dir.exists():
+            session_hooks = [
+                "sessions-enforce.py", "session-start.py", "user-messages.py",
+                "post-tool-use.py", "task-completion-workflow.py",
+                "post-implementation-retention.py", "task-transcript-link.py"
+            ]
+            for hook in session_hooks:
+                hook_file = hooks_dir / hook
+                if hook_file.exists():
+                    components["hooks"].append(str(hook_file))
+
+        # Scan agents
+        agents_dir = self.project_root / ".claude/agents"
+        if agents_dir.exists():
+            for agent_file in agents_dir.glob("*.md"):
+                components["agents"].append(str(agent_file))
+
+        # Scan commands
+        commands_dir = self.project_root / ".claude/commands"
+        if commands_dir.exists():
+            session_commands = ["sync-*.md", "build-project.md", "project.py"]
+            for pattern in session_commands:
+                for cmd_file in commands_dir.glob(pattern):
+                    components["commands"].append(str(cmd_file))
+
+        # Scan protocols
+        protocols_dir = self.project_root / "sessions/protocols"
+        if protocols_dir.exists():
+            for protocol_file in protocols_dir.glob("*.md"):
+                components["protocols"].append(str(protocol_file))
+
+        # Scan templates
+        template_file = self.project_root / "sessions/tasks/TEMPLATE.md"
+        if template_file.exists():
+            components["templates"].append(str(template_file))
+
+        # Scan knowledge
+        knowledge_dir = self.project_root / "sessions/knowledge/claude-code"
+        if knowledge_dir.exists():
+            components["knowledge"].append(str(knowledge_dir))
+
+        # Scan state files
+        state_dir = self.project_root / ".claude/state"
+        if state_dir.exists():
+            session_state_files = ["daic-mode.json"]
+            for state_file in session_state_files:
+                state_path = state_dir / state_file
+                if state_path.exists():
+                    components["state"].append(str(state_path))
+
+        # Scan statusline
+        statusline_file = self.project_root / ".claude/statusline-script.sh"
+        if statusline_file.exists():
+            components["state"].append(str(statusline_file))
+
+        return components
+
+    def _scan_global_commands(self) -> List[str]:
+        """
+        Scan for globally installed cc-sessions commands
+
+        Returns:
+            List[str]: Paths to global commands
+        """
+        global_commands = []
+
+        if self.platform == 'windows':
+            # Windows installation location
+            local_bin = Path.home() / "AppData" / "Local" / "cc-sessions" / "bin"
+            for cmd_file in ["daic.cmd", "daic.ps1"]:
+                cmd_path = local_bin / cmd_file
+                if cmd_path.exists():
+                    global_commands.append(str(cmd_path))
+        else:
+            # Unix/Mac installation location
+            daic_path = Path("/usr/local/bin/daic")
+            if daic_path.exists():
+                global_commands.append(str(daic_path))
+
+        return global_commands
+
+    def _scan_settings_hooks(self) -> Dict[str, Any]:
+        """
+        Scan for cc-sessions hooks in settings.json
+
+        Returns:
+            Dict: Settings hooks information
+        """
+        settings_file = self.project_root / ".claude/settings.json"
+        if not settings_file.exists():
+            return {"exists": False}
+
+        try:
+            with open(settings_file) as f:
+                settings = json.load(f)
+
+            # Look for cc-sessions hooks
+            sessions_hooks = []
+            if "hooks" in settings:
+                for hook_type, hook_configs in settings["hooks"].items():
+                    for config in hook_configs:
+                        if "hooks" in config:
+                            for hook in config["hooks"]:
+                                command = hook.get("command", "")
+                                if ("sessions-enforce.py" in command or
+                                    "session-start.py" in command or
+                                    "user-messages.py" in command or
+                                    "post-tool-use.py" in command or
+                                    "task-completion-workflow.py" in command or
+                                    "post-implementation-retention.py" in command or
+                                    "task-transcript-link.py" in command):
+                                    sessions_hooks.append({
+                                        "type": hook_type,
+                                        "command": command
+                                    })
+
+            return {
+                "exists": True,
+                "file": str(settings_file),
+                "sessions_hooks": sessions_hooks,
+                "has_statusline": "statusLine" in settings
+            }
+        except Exception:
+            return {"exists": True, "file": str(settings_file), "error": True}
+
+    def create_backup(self, backup_name: Optional[str] = None) -> Tuple[bool, str]:
+        """
+        Create a compressed backup of the current cc-sessions installation
+
+        Args:
+            backup_name: Optional custom backup name
+
+        Returns:
+            Tuple[bool, str]: Success status and backup file path
+        """
+        if not self.installation:
+            return False, "No cc-sessions installation found to backup"
+
+        # Create backup directory
+        backup_dir = self.project_root / "sessions" / "backups"
+        backup_dir.mkdir(parents=True, exist_ok=True)
+
+        # Generate backup filename
+        if not backup_name:
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            backup_name = f"cc-sessions-backup-{timestamp}"
+
+        backup_file = backup_dir / f"{backup_name}.tar.gz"
+        metadata_file = backup_dir / f"{backup_name}.json"
+
+        try:
+            print(color(f"Creating backup: {backup_file.name}", Colors.CYAN))
+
+            # Create compressed backup
+            with tarfile.open(backup_file, "w:gz") as tar:
+                # Add configuration file
+                if self.installation["config_file"].exists():
+                    tar.add(self.installation["config_file"],
+                           arcname=f"sessions/sessions-config.json")
+
+                # Add all components
+                for category, files in self.installation["components"].items():
+                    for file_path in files:
+                        file_obj = Path(file_path)
+                        if file_obj.exists():
+                            # Calculate relative path for extraction
+                            rel_path = file_obj.relative_to(self.project_root)
+                            tar.add(file_obj, arcname=str(rel_path))
+
+                # Add settings.json hooks if they exist
+                settings_info = self.installation["settings_hooks"]
+                if settings_info.get("exists") and not settings_info.get("error"):
+                    settings_file = Path(settings_info["file"])
+                    if settings_file.exists():
+                        tar.add(settings_file,
+                               arcname=".claude/settings.json")
+
+            # Create metadata file
+            metadata = {
+                "version": self.installation["version"],
+                "platform": self.platform,
+                "date": datetime.now().isoformat(),
+                "components": self.installation["components"],
+                "global_commands": self.installation["global_commands"],
+                "settings_hooks": self.installation["settings_hooks"]
+            }
+
+            with open(metadata_file, 'w') as f:
+                json.dump(metadata, f, indent=2)
+
+            print(color(f"✓ Backup created successfully: {backup_file.name}", Colors.GREEN))
+            return True, str(backup_file)
+
+        except Exception as e:
+            print(color(f"❌ Backup creation failed: {e}", Colors.RED))
+            return False, str(e)
+
+    def show_main_menu(self) -> str:
+        """
+        Show the main uninstaller menu
+
+        Returns:
+            str: User's menu choice
+        """
+        print()
+        print(color("╔══════════════════════════════════════════════════════════════╗", Colors.BRIGHT + Colors.CYAN))
+        print(color("║              cc-sessions Safe Uninstaller                    ║", Colors.BRIGHT + Colors.CYAN))
+        print(color("╚══════════════════════════════════════════════════════════════╝", Colors.BRIGHT + Colors.CYAN))
+        print()
+
+        if not self.installation:
+            print(color("❌ No cc-sessions installation found in this directory", Colors.RED))
+            print(color("   Make sure you're in a project directory with cc-sessions installed", Colors.DIM))
+            return "exit"
+
+        # Show installation summary
+        total_components = sum(len(files) for files in self.installation["components"].values())
+        print(color(f"  📦 Found cc-sessions v{self.installation['version']} ({self.platform})", Colors.WHITE))
+        print(color(f"  📁 {total_components} components detected", Colors.WHITE))
+        print(color(f"  🌐 {len(self.installation['global_commands'])} global commands", Colors.WHITE))
+        print()
+
+        print(color("  What would you like to do?", Colors.CYAN))
+        print(color("  1. Complete Uninstall (safe - preserves user tasks)", Colors.WHITE))
+        print(color("  2. Selective Uninstall (choose components)", Colors.YELLOW))
+        print(color("  3. Backup Only (create backup without removing)", Colors.BLUE))
+        print(color("  4. Restore from Backup (restore previous installation)", Colors.MAGENTA))
+        print(color("  5. Dry Run (preview what would be removed)", Colors.GREEN))
+        print(color("  6. Exit (no changes)", Colors.DIM))
+        print()
+
+        while True:
+            choice = input(color("  Your choice (1-6): ", Colors.CYAN))
+            if choice in ['1', '2', '3', '4', '5', '6']:
+                return {
+                    '1': 'complete',
+                    '2': 'selective',
+                    '3': 'backup',
+                    '4': 'restore',
+                    '5': 'dry_run',
+                    '6': 'exit'
+                }[choice]
+            print(color("  Please enter 1, 2, 3, 4, 5, or 6", Colors.YELLOW))
+
+    def perform_dry_run(self) -> None:
+        """Show what would be removed without actually removing anything"""
+        print()
+        print(color("🔍 DRY RUN - Preview of what would be removed:", Colors.BRIGHT + Colors.GREEN))
+        print(color("═" * 60, Colors.DIM))
+
+        total_files = 0
+
+        for category, files in self.installation["components"].items():
+            if files:
+                print(color(f"\n  {category.upper()}:", Colors.CYAN))
+                for file_path in files:
+                    print(color(f"    - {file_path}", Colors.WHITE))
+                    total_files += 1
+
+        if self.installation["global_commands"]:
+            print(color(f"\n  GLOBAL COMMANDS:", Colors.CYAN))
+            for cmd_path in self.installation["global_commands"]:
+                print(color(f"    - {cmd_path}", Colors.WHITE))
+                total_files += 1
+
+        # Show settings.json changes
+        settings_info = self.installation["settings_hooks"]
+        if settings_info.get("sessions_hooks"):
+            print(color(f"\n  SETTINGS.JSON HOOKS:", Colors.CYAN))
+            for hook in settings_info["sessions_hooks"]:
+                print(color(f"    - {hook['type']}: {hook['command']}", Colors.WHITE))
+
+        # Show what would be preserved
+        print(color(f"\n  PRESERVED (will NOT be removed):", Colors.GREEN))
+        print(color(f"    - User tasks in sessions/tasks/ (except TEMPLATE.md)", Colors.GREEN))
+        print(color(f"    - Work logs and task content", Colors.GREEN))
+        print(color(f"    - CLAUDE.md and CLAUDE.sessions.md", Colors.GREEN))
+        print(color(f"    - Current task state (.claude/state/current_task.json)", Colors.GREEN))
+        print(color(f"    - Existing backups", Colors.GREEN))
+        print(color(f"    - Non-sessions settings in .claude/settings.json", Colors.GREEN))
+
+        print()
+        print(color(f"📊 SUMMARY: {total_files} files would be removed", Colors.BRIGHT + Colors.YELLOW))
+        print(color("   User data and work would be preserved", Colors.GREEN))
+
+    def perform_complete_uninstall(self, create_backup: bool = True) -> bool:
+        """
+        Perform complete uninstall of cc-sessions
+
+        Args:
+            create_backup: Whether to create backup before removal
+
+        Returns:
+            bool: Success status
+        """
+        print()
+        print(color("🗑️  COMPLETE UNINSTALL", Colors.BRIGHT + Colors.RED))
+        print(color("─" * 30, Colors.DIM))
+
+        # Create backup if requested
+        if create_backup:
+            if not ask_yes_no("Create backup before uninstalling?", default=True):
+                if not ask_yes_no("Are you sure you want to proceed without backup?", default=False):
+                    print(color("  Uninstall cancelled", Colors.YELLOW))
+                    return False
+            else:
+                success, backup_path = self.create_backup()
+                if not success:
+                    print(color(f"  Backup failed: {backup_path}", Colors.RED))
+                    if not ask_yes_no("Continue uninstall without backup?", default=False):
+                        return False
+
+        # Final confirmation
+        print(color("\n⚠️  This will remove ALL cc-sessions components!", Colors.BRIGHT + Colors.RED))
+        print(color("   User tasks and work logs will be preserved", Colors.GREEN))
+
+        if not ask_yes_no("Proceed with complete uninstall?", default=False):
+            print(color("  Uninstall cancelled", Colors.YELLOW))
+            return False
+
+        try:
+            return self._remove_all_components()
+        except Exception as e:
+            print(color(f"❌ Uninstall failed: {e}", Colors.RED))
+            return False
+
+    def _remove_all_components(self) -> bool:
+        """
+        Remove all cc-sessions components
+
+        Returns:
+            bool: Success status
+        """
+        print(color("\n🔄 Removing cc-sessions components...", Colors.CYAN))
+
+        removed_count = 0
+        error_count = 0
+
+        # Remove component files
+        for category, files in self.installation["components"].items():
+            if files:
+                print(color(f"  Removing {category}...", Colors.DIM))
+                for file_path in files:
+                    try:
+                        file_obj = Path(file_path)
+                        if file_obj.exists():
+                            if file_obj.is_dir():
+                                shutil.rmtree(file_obj)
+                            else:
+                                file_obj.unlink()
+                            removed_count += 1
+                    except Exception as e:
+                        print(color(f"    ⚠️  Could not remove {file_path}: {e}", Colors.YELLOW))
+                        error_count += 1
+
+        # Remove global commands
+        if self.installation["global_commands"]:
+            print(color("  Removing global commands...", Colors.DIM))
+            for cmd_path in self.installation["global_commands"]:
+                try:
+                    cmd_obj = Path(cmd_path)
+                    if cmd_obj.exists():
+                        # May need sudo for Unix systems
+                        if self.platform in ['macos', 'linux'] and str(cmd_obj).startswith('/usr/'):
+                            subprocess.run(["sudo", "rm", str(cmd_obj)], check=True)
+                        else:
+                            cmd_obj.unlink()
+                        removed_count += 1
+                except Exception as e:
+                    print(color(f"    ⚠️  Could not remove {cmd_path}: {e}", Colors.YELLOW))
+                    error_count += 1
+
+        # Clean up settings.json hooks
+        self._remove_settings_hooks()
+
+        # Remove configuration file
+        try:
+            if self.installation["config_file"].exists():
+                self.installation["config_file"].unlink()
+                removed_count += 1
+        except Exception as e:
+            print(color(f"    ⚠️  Could not remove config file: {e}", Colors.YELLOW))
+            error_count += 1
+
+        # Remove empty directories
+        self._cleanup_empty_directories()
+
+        # Summary
+        print()
+        if error_count == 0:
+            print(color("╔═══════════════════════════════════════════════╗", Colors.BRIGHT + Colors.GREEN))
+            print(color("║           🎉 UNINSTALL COMPLETE! 🎉           ║", Colors.BRIGHT + Colors.GREEN))
+            print(color("╚═══════════════════════════════════════════════╝", Colors.BRIGHT + Colors.GREEN))
+        else:
+            print(color("╔═══════════════════════════════════════════════╗", Colors.BRIGHT + Colors.YELLOW))
+            print(color("║         UNINSTALL COMPLETED WITH WARNINGS     ║", Colors.BRIGHT + Colors.YELLOW))
+            print(color("╚═══════════════════════════════════════════════╝", Colors.BRIGHT + Colors.YELLOW))
+
+        print()
+        print(color(f"  ✓ {removed_count} components removed", Colors.GREEN))
+        if error_count > 0:
+            print(color(f"  ⚠️  {error_count} items had removal issues", Colors.YELLOW))
+        print(color("  ✓ User tasks and work preserved", Colors.GREEN))
+
+        return error_count == 0
+
+    def _remove_settings_hooks(self) -> None:
+        """Remove cc-sessions hooks from settings.json while preserving other settings"""
+        settings_info = self.installation["settings_hooks"]
+        if not settings_info.get("exists") or settings_info.get("error"):
+            return
+
+        try:
+            settings_file = Path(settings_info["file"])
+            with open(settings_file) as f:
+                settings = json.load(f)
+
+            # Remove cc-sessions hooks
+            if "hooks" in settings:
+                for hook_type in list(settings["hooks"].keys()):
+                    if hook_type in settings["hooks"]:
+                        # Filter out sessions hooks
+                        filtered_configs = []
+                        for config in settings["hooks"][hook_type]:
+                            if "hooks" in config:
+                                filtered_hooks = []
+                                for hook in config["hooks"]:
+                                    command = hook.get("command", "")
+                                    if not any(sessions_hook in command for sessions_hook in [
+                                        "sessions-enforce.py", "session-start.py", "user-messages.py",
+                                        "post-tool-use.py", "task-completion-workflow.py",
+                                        "post-implementation-retention.py", "task-transcript-link.py"
+                                    ]):
+                                        filtered_hooks.append(hook)
+
+                                if filtered_hooks:
+                                    config["hooks"] = filtered_hooks
+                                    filtered_configs.append(config)
+                                elif len(config) > 1:  # Has other properties besides hooks
+                                    del config["hooks"]
+                                    filtered_configs.append(config)
+                            else:
+                                filtered_configs.append(config)
+
+                        if filtered_configs:
+                            settings["hooks"][hook_type] = filtered_configs
+                        else:
+                            del settings["hooks"][hook_type]
+
+                # Remove hooks section if empty
+                if not settings["hooks"]:
+                    del settings["hooks"]
+
+            # Remove statusline if it's sessions-related
+            if settings_info.get("has_statusline"):
+                if "statusLine" in settings:
+                    statusline = settings["statusLine"]
+                    if "statusline-script.sh" in statusline.get("command", ""):
+                        del settings["statusLine"]
+
+            # Save updated settings
+            with open(settings_file, 'w') as f:
+                json.dump(settings, f, indent=2)
+
+            print(color("  ✓ Cleaned cc-sessions hooks from settings.json", Colors.GREEN))
+
+        except Exception as e:
+            print(color(f"  ⚠️  Could not clean settings.json: {e}", Colors.YELLOW))
+
+    def _cleanup_empty_directories(self) -> None:
+        """Remove empty directories left behind after uninstall"""
+        dirs_to_check = [
+            self.project_root / ".claude/hooks",
+            self.project_root / ".claude/agents",
+            self.project_root / ".claude/commands",
+            self.project_root / "sessions/protocols",
+            self.project_root / "sessions/knowledge/claude-code",
+            self.project_root / "sessions/knowledge"
+        ]
+
+        for dir_path in dirs_to_check:
+            try:
+                if dir_path.exists() and dir_path.is_dir():
+                    # Only remove if empty
+                    if not any(dir_path.iterdir()):
+                        dir_path.rmdir()
+            except Exception:
+                pass  # Ignore errors for directory cleanup
+
+    def list_backups(self) -> List[Tuple[str, str, str]]:
+        """
+        List available backups
+
+        Returns:
+            List[Tuple[str, str, str]]: List of (name, date, version) tuples
+        """
+        backup_dir = self.project_root / "sessions" / "backups"
+        if not backup_dir.exists():
+            return []
+
+        backups = []
+        for backup_file in backup_dir.glob("cc-sessions-backup-*.tar.gz"):
+            metadata_file = backup_file.with_suffix('.json')
+            if metadata_file.exists():
+                try:
+                    with open(metadata_file) as f:
+                        metadata = json.load(f)
+
+                    name = backup_file.stem
+                    date = metadata.get("date", "unknown")
+                    version = metadata.get("version", "unknown")
+                    backups.append((name, date, version))
+                except Exception:
+                    pass
+
+        return sorted(backups, key=lambda x: x[1], reverse=True)
+
+    def run(self) -> None:
+        """Run the main uninstaller interface"""
+        print(color("╔════════════════════════════════════════════════════════════╗", Colors.BRIGHT))
+        print(color("║              cc-sessions Safe Uninstaller                  ║", Colors.BRIGHT))
+        print(color("╚════════════════════════════════════════════════════════════╝", Colors.BRIGHT))
+        print()
+        print(color(f"Platform: {self.platform.upper()}", Colors.DIM))
+        print(color(f"Project: {self.project_root}", Colors.DIM))
+
+        while True:
+            choice = self.show_main_menu()
+
+            if choice == 'exit':
+                print(color("\n  👋 No changes made. Exiting...", Colors.CYAN))
+                break
+            elif choice == 'complete':
+                self.perform_complete_uninstall()
+                break
+            elif choice == 'selective':
+                print(color("\n  📝 Selective uninstall not yet implemented", Colors.YELLOW))
+                print(color("     Use complete uninstall for now", Colors.DIM))
+            elif choice == 'backup':
+                success, backup_path = self.create_backup()
+                if success:
+                    print(color(f"  ✓ Backup created: {backup_path}", Colors.GREEN))
+            elif choice == 'restore':
+                backups = self.list_backups()
+                if not backups:
+                    print(color("\n  📂 No backups found", Colors.YELLOW))
+                else:
+                    print(color("\n  📝 Restore functionality not yet implemented", Colors.YELLOW))
+                    print(color("     Available backups:", Colors.DIM))
+                    for name, date, version in backups:
+                        print(color(f"       - {name} (v{version}, {date[:10]})", Colors.WHITE))
+            elif choice == 'dry_run':
+                self.perform_dry_run()
+
+def main():
+    """Main entry point for the uninstaller"""
+    try:
+        uninstaller = SessionsUninstaller()
+        uninstaller.run()
+    except KeyboardInterrupt:
+        print(color("\n\n  Uninstaller interrupted by user", Colors.YELLOW))
+        sys.exit(1)
+    except Exception as e:
+        print(color(f"\n❌ Uninstaller error: {e}", Colors.RED))
+        sys.exit(1)
+
+def uninstall():
+    """Alias for main() for compatibility"""
+    main()
+
+if __name__ == "__main__":
+    main()

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "cc-sessions",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Claude Code Sessions Framework - Enforced methodology for AI pair programming",
   "main": "install.js",
   "bin": {
     "cc-sessions": "install.js",
-    "cc-sessions-install": "install.js"
+    "cc-sessions-install": "install.js",
+    "cc-sessions-uninstall": "uninstall.js"
   },
   "scripts": {
     "test": "echo \"No test specified yet\""
@@ -42,6 +43,7 @@
   "preferGlobal": true,
   "files": [
     "install.js",
+    "uninstall.js",
     "install.sh",
     "cc_sessions/",
     "docs/",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cc-sessions"
-version = "0.2.6"
+version = "0.2.7"
 description = "Claude Code Sessions Framework - Enforced methodology for AI pair programming"
 readme = "README.md"
 license = {text = "MIT"}
@@ -50,6 +50,7 @@ Issues = "https://github.com/GWUDCAP/cc-sessions/issues"
 [project.scripts]
 cc-sessions = "cc_sessions.install:main"
 cc-sessions-install = "cc_sessions.install:main"
+cc-sessions-uninstall = "cc_sessions.uninstall:main"
 
 [tool.setuptools]
 packages = ["cc_sessions"]

--- a/scripts/auto-version-bump.py
+++ b/scripts/auto-version-bump.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+Auto-version bump script for cc-sessions
+Automatically increments patch version when significant files are modified
+"""
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+def get_git_diff_files():
+    """Get list of staged files for commit"""
+    try:
+        result = subprocess.run(['git', 'diff', '--cached', '--name-only'],
+                              capture_output=True, text=True, check=True)
+        return result.stdout.strip().split('\n') if result.stdout.strip() else []
+    except subprocess.CalledProcessError:
+        return []
+
+def should_bump_version(changed_files):
+    """Check if changes warrant a version bump"""
+    significant_patterns = [
+        'cc_sessions/install.py',
+        'cc_sessions/uninstall.py',
+        'install.js',
+        'uninstall.js',
+        'cc_sessions/hooks/',
+        'cc_sessions/agents/',
+        'cc_sessions/commands/',
+        'cc_sessions/protocols/',
+        'cc_sessions/templates/',
+        'pyproject.toml',
+        'package.json'
+    ]
+
+    for file in changed_files:
+        for pattern in significant_patterns:
+            if pattern in file:
+                return True
+    return False
+
+def bump_version(version_str, bump_type='patch'):
+    """Bump version string"""
+    parts = version_str.split('.')
+    major, minor, patch = int(parts[0]), int(parts[1]), int(parts[2])
+
+    if bump_type == 'patch':
+        patch += 1
+    elif bump_type == 'minor':
+        minor += 1
+        patch = 0
+    elif bump_type == 'major':
+        major += 1
+        minor = 0
+        patch = 0
+
+    return f"{major}.{minor}.{patch}"
+
+def update_pyproject_version(new_version):
+    """Update version in pyproject.toml"""
+    pyproject_path = Path('pyproject.toml')
+    if not pyproject_path.exists():
+        return False
+
+    content = pyproject_path.read_text()
+    updated_content = re.sub(
+        r'version = "[^"]*"',
+        f'version = "{new_version}"',
+        content
+    )
+
+    if content != updated_content:
+        pyproject_path.write_text(updated_content)
+        return True
+    return False
+
+def update_package_json_version(new_version):
+    """Update version in package.json"""
+    package_path = Path('package.json')
+    if not package_path.exists():
+        return False
+
+    with open(package_path) as f:
+        data = json.load(f)
+
+    old_version = data.get('version')
+    if old_version != new_version:
+        data['version'] = new_version
+        with open(package_path, 'w') as f:
+            json.dump(data, f, indent=2)
+        return True
+    return False
+
+def main():
+    # Get current staged files
+    changed_files = get_git_diff_files()
+
+    if not should_bump_version(changed_files):
+        print("No significant changes detected, skipping version bump")
+        return 0
+
+    # Read current version from pyproject.toml
+    pyproject_path = Path('pyproject.toml')
+    if not pyproject_path.exists():
+        print("pyproject.toml not found")
+        return 1
+
+    content = pyproject_path.read_text()
+    version_match = re.search(r'version = "([^"]*)"', content)
+    if not version_match:
+        print("Could not find version in pyproject.toml")
+        return 1
+
+    current_version = version_match.group(1)
+    new_version = bump_version(current_version)
+
+    print(f"Auto-bumping version: {current_version} → {new_version}")
+
+    # Update both files
+    updated_pyproject = update_pyproject_version(new_version)
+    updated_package = update_package_json_version(new_version)
+
+    if updated_pyproject or updated_package:
+        # Stage the version files
+        if updated_pyproject:
+            subprocess.run(['git', 'add', 'pyproject.toml'])
+        if updated_package:
+            subprocess.run(['git', 'add', 'package.json'])
+
+        print(f"Version bumped to {new_version}")
+
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/uninstall.js
+++ b/uninstall.js
@@ -1,0 +1,969 @@
+#!/usr/bin/env node
+
+/**
+ * Claude Code Sessions Framework - Cross-Platform Node.js Uninstaller
+ *
+ * NPM wrapper uninstaller providing identical functionality to the Python uninstaller
+ * with native Windows, macOS, Linux, and WSL support. Features comprehensive backup
+ * system, safe removal with user data preservation, and interactive terminal UI.
+ *
+ * Key Features:
+ *   - Cross-platform compatibility (Windows, macOS, Linux, WSL)
+ *   - Comprehensive backup system with compression
+ *   - Restore functionality from backups
+ *   - Interactive menu with multiple uninstall modes
+ *   - Dry-run mode for safety testing
+ *   - Selective component removal
+ *   - Preservation of user tasks and work logs
+ *
+ * Platform Support:
+ *   - Windows 10/11 (Command Prompt, PowerShell, Git Bash)
+ *   - macOS (Terminal, iTerm2 with Bash/Zsh)
+ *   - Linux distributions (various terminals and shells)
+ *   - WSL (Windows Subsystem for Linux)
+ *
+ * Usage:
+ *   - npm uninstall -g cc-sessions (removes package)
+ *   - npx cc-sessions-uninstall (runs this uninstaller)
+ *   - cc-sessions-uninstall (if globally installed)
+ *
+ * Safety Features:
+ *   - Dry-run mode shows what would be removed
+ *   - Multiple confirmation prompts
+ *   - Atomic operations (all-or-nothing)
+ *   - User data preservation (tasks, work logs)
+ *   - Backup validation before removal
+ *
+ * @module uninstall
+ * @requires fs
+ * @requires path
+ * @requires child_process
+ * @requires readline
+ * @requires zlib
+ * @requires tar
+ */
+
+const fs = require('fs').promises;
+const fsSync = require('fs');
+const path = require('path');
+const { execSync, spawn } = require('child_process');
+const readline = require('readline');
+const { promisify } = require('util');
+const zlib = require('zlib');
+let tar;
+try {
+  tar = require('tar');
+} catch (e) {
+  // tar module not available - backup functionality will be limited
+}
+const os = require('os');
+
+// Colors for terminal output
+const colors = {
+  reset: '\x1b[0m',
+  bright: '\x1b[1m',
+  dim: '\x1b[2m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  magenta: '\x1b[35m',
+  cyan: '\x1b[36m',
+  white: '\x1b[37m',
+  bgRed: '\x1b[41m',
+  bgGreen: '\x1b[42m',
+  bgYellow: '\x1b[43m'
+};
+
+// Helper to colorize output
+const color = (text, colorCode) => `${colorCode}${text}${colors.reset}`;
+
+// Create readline interface
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+const question = promisify(rl.question).bind(rl);
+
+/**
+ * Ask a yes/no question with a default option
+ * @param {string} prompt - The question to ask
+ * @param {boolean} defaultValue - True for yes default (Y/n), False for no default (y/N)
+ * @returns {Promise<boolean>} - True for yes, False for no
+ */
+async function askYesNo(prompt, defaultValue = true) {
+  const suffix = defaultValue ? ' (Y/n): ' : ' (y/N): ';
+
+  while (true) {
+    const response = (await question(color(prompt + suffix, colors.cyan))).trim().toLowerCase();
+
+    if (response === '') {
+      return defaultValue;
+    } else if (['y', 'yes'].includes(response)) {
+      return true;
+    } else if (['n', 'no'].includes(response)) {
+      return false;
+    } else {
+      console.log(color('  Please enter y, n, yes, no, or press Enter for default', colors.yellow));
+    }
+  }
+}
+
+/**
+ * Detect the current platform with special handling for WSL
+ * @returns {string} - 'windows', 'macos', 'linux', or 'wsl'
+ */
+function detectPlatform() {
+  if (process.platform === 'win32') {
+    return 'windows';
+  } else if (process.platform === 'darwin') {
+    return 'macos';
+  } else {
+    // Check for WSL
+    try {
+      if (fsSync.existsSync('/proc/sys/fs/binfmt_misc/WSLInterop')) {
+        return 'wsl';
+      }
+    } catch (e) {
+      // Ignore errors
+    }
+    return 'linux';
+  }
+}
+
+/**
+ * Check if a command exists in the system
+ * @param {string} command - Command to check
+ * @returns {boolean} - True if command exists
+ */
+function commandExists(command) {
+  try {
+    const checkCmd = process.platform === 'win32' ? 'where' : 'which';
+    execSync(`${checkCmd} ${command}`, { stdio: 'ignore' });
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+/**
+ * Main uninstaller class for cc-sessions framework
+ */
+class SessionsUninstaller {
+  constructor() {
+    this.platform = detectPlatform();
+    this.projectRoot = this.detectProjectDirectory();
+    this.installation = null;
+  }
+
+  /**
+   * Detect the correct project directory
+   * @returns {string} - Project directory path
+   */
+  detectProjectDirectory() {
+    const currentDir = process.cwd();
+
+    // If running from node_modules (global install)
+    if (currentDir.includes('node_modules') || currentDir.includes('.npm')) {
+      console.log(color('⚠️  Running from package directory, not project directory.', colors.yellow));
+      console.log();
+      // This would need user input in a real implementation
+      return process.cwd();
+    }
+
+    return currentDir;
+  }
+
+  /**
+   * Detect if cc-sessions is installed in this project
+   * @returns {Promise<Object|null>} - Installation details or null
+   */
+  async detectInstallation() {
+    const configFile = path.join(this.projectRoot, 'sessions', 'sessions-config.json');
+
+    try {
+      await fs.access(configFile);
+      const configContent = await fs.readFile(configFile, 'utf8');
+      const config = JSON.parse(configContent);
+
+      // Collect installation details
+      const installation = {
+        configFile,
+        config,
+        version: config.version || 'unknown',
+        platform: this.platform,
+        components: await this.scanComponents(),
+        globalCommands: await this.scanGlobalCommands(),
+        settingsHooks: await this.scanSettingsHooks()
+      };
+
+      return installation;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  /**
+   * Scan for installed cc-sessions components
+   * @returns {Promise<Object>} - Components organized by category
+   */
+  async scanComponents() {
+    const components = {
+      hooks: [],
+      agents: [],
+      commands: [],
+      protocols: [],
+      templates: [],
+      knowledge: [],
+      state: []
+    };
+
+    // Scan hooks
+    const hooksDir = path.join(this.projectRoot, '.claude', 'hooks');
+    const sessionHooks = [
+      'sessions-enforce.py', 'session-start.py', 'user-messages.py',
+      'post-tool-use.py', 'task-completion-workflow.py',
+      'post-implementation-retention.py', 'task-transcript-link.py'
+    ];
+
+    for (const hook of sessionHooks) {
+      const hookFile = path.join(hooksDir, hook);
+      try {
+        await fs.access(hookFile);
+        components.hooks.push(hookFile);
+      } catch (e) {
+        // File doesn't exist, skip
+      }
+    }
+
+    // Scan agents
+    const agentsDir = path.join(this.projectRoot, '.claude', 'agents');
+    try {
+      const agentFiles = await fs.readdir(agentsDir);
+      for (const file of agentFiles) {
+        if (file.endsWith('.md')) {
+          components.agents.push(path.join(agentsDir, file));
+        }
+      }
+    } catch (e) {
+      // Directory doesn't exist
+    }
+
+    // Scan commands
+    const commandsDir = path.join(this.projectRoot, '.claude', 'commands');
+    const sessionCommandPatterns = ['sync-', 'build-project.md', 'project.py'];
+    try {
+      const commandFiles = await fs.readdir(commandsDir);
+      for (const file of commandFiles) {
+        if (sessionCommandPatterns.some(pattern => file.includes(pattern))) {
+          components.commands.push(path.join(commandsDir, file));
+        }
+      }
+    } catch (e) {
+      // Directory doesn't exist
+    }
+
+    // Scan protocols
+    const protocolsDir = path.join(this.projectRoot, 'sessions', 'protocols');
+    try {
+      const protocolFiles = await fs.readdir(protocolsDir);
+      for (const file of protocolFiles) {
+        if (file.endsWith('.md')) {
+          components.protocols.push(path.join(protocolsDir, file));
+        }
+      }
+    } catch (e) {
+      // Directory doesn't exist
+    }
+
+    // Scan templates
+    const templateFile = path.join(this.projectRoot, 'sessions', 'tasks', 'TEMPLATE.md');
+    try {
+      await fs.access(templateFile);
+      components.templates.push(templateFile);
+    } catch (e) {
+      // File doesn't exist
+    }
+
+    // Scan knowledge
+    const knowledgeDir = path.join(this.projectRoot, 'sessions', 'knowledge', 'claude-code');
+    try {
+      await fs.access(knowledgeDir);
+      components.knowledge.push(knowledgeDir);
+    } catch (e) {
+      // Directory doesn't exist
+    }
+
+    // Scan state files
+    const stateDir = path.join(this.projectRoot, '.claude', 'state');
+    const sessionStateFiles = ['daic-mode.json'];
+    for (const stateFile of sessionStateFiles) {
+      const statePath = path.join(stateDir, stateFile);
+      try {
+        await fs.access(statePath);
+        components.state.push(statePath);
+      } catch (e) {
+        // File doesn't exist
+      }
+    }
+
+    // Scan statusline
+    const statuslineFile = path.join(this.projectRoot, '.claude', 'statusline-script.sh');
+    try {
+      await fs.access(statuslineFile);
+      components.state.push(statuslineFile);
+    } catch (e) {
+      // File doesn't exist
+    }
+
+    return components;
+  }
+
+  /**
+   * Scan for globally installed cc-sessions commands
+   * @returns {Promise<Array>} - Paths to global commands
+   */
+  async scanGlobalCommands() {
+    const globalCommands = [];
+
+    if (this.platform === 'windows') {
+      // Windows installation location
+      const localBin = path.join(os.homedir(), 'AppData', 'Local', 'cc-sessions', 'bin');
+      const cmdFiles = ['daic.cmd', 'daic.ps1'];
+
+      for (const cmdFile of cmdFiles) {
+        const cmdPath = path.join(localBin, cmdFile);
+        try {
+          await fs.access(cmdPath);
+          globalCommands.push(cmdPath);
+        } catch (e) {
+          // File doesn't exist
+        }
+      }
+    } else {
+      // Unix/Mac installation location
+      const daicPath = '/usr/local/bin/daic';
+      try {
+        await fs.access(daicPath);
+        globalCommands.push(daicPath);
+      } catch (e) {
+        // File doesn't exist
+      }
+    }
+
+    return globalCommands;
+  }
+
+  /**
+   * Scan for cc-sessions hooks in settings.json
+   * @returns {Promise<Object>} - Settings hooks information
+   */
+  async scanSettingsHooks() {
+    const settingsFile = path.join(this.projectRoot, '.claude', 'settings.json');
+
+    try {
+      await fs.access(settingsFile);
+      const settingsContent = await fs.readFile(settingsFile, 'utf8');
+      const settings = JSON.parse(settingsContent);
+
+      // Look for cc-sessions hooks
+      const sessionsHooks = [];
+      if (settings.hooks) {
+        for (const [hookType, hookConfigs] of Object.entries(settings.hooks)) {
+          for (const config of hookConfigs) {
+            if (config.hooks) {
+              for (const hook of config.hooks) {
+                const command = hook.command || '';
+                if (command.includes('sessions-enforce.py') ||
+                    command.includes('session-start.py') ||
+                    command.includes('user-messages.py') ||
+                    command.includes('post-tool-use.py') ||
+                    command.includes('task-completion-workflow.py') ||
+                    command.includes('post-implementation-retention.py') ||
+                    command.includes('task-transcript-link.py')) {
+                  sessionsHooks.push({
+                    type: hookType,
+                    command: command
+                  });
+                }
+              }
+            }
+          }
+        }
+      }
+
+      return {
+        exists: true,
+        file: settingsFile,
+        sessionsHooks: sessionsHooks,
+        hasStatusline: !!settings.statusLine
+      };
+    } catch (e) {
+      return { exists: false };
+    }
+  }
+
+  /**
+   * Create a compressed backup of the current cc-sessions installation
+   * @param {string} backupName - Optional custom backup name
+   * @returns {Promise<[boolean, string]>} - Success status and backup file path
+   */
+  async createBackup(backupName = null) {
+    if (!this.installation) {
+      return [false, 'No cc-sessions installation found to backup'];
+    }
+
+    // Create backup directory
+    const backupDir = path.join(this.projectRoot, 'sessions', 'backups');
+    try {
+      await fs.mkdir(backupDir, { recursive: true });
+    } catch (e) {
+      // Directory might already exist
+    }
+
+    // Generate backup filename
+    if (!backupName) {
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-').split('T');
+      backupName = `cc-sessions-backup-${timestamp[0]}_${timestamp[1].split('.')[0]}`;
+    }
+
+    const backupFile = path.join(backupDir, `${backupName}.tar.gz`);
+    const metadataFile = path.join(backupDir, `${backupName}.json`);
+
+    try {
+      console.log(color(`Creating backup: ${path.basename(backupFile)}`, colors.cyan));
+
+      // Create list of files to backup
+      const filesToBackup = [];
+
+      // Add configuration file
+      if (fsSync.existsSync(this.installation.configFile)) {
+        filesToBackup.push({
+          src: this.installation.configFile,
+          dest: 'sessions/sessions-config.json'
+        });
+      }
+
+      // Add all components
+      for (const [category, files] of Object.entries(this.installation.components)) {
+        for (const filePath of files) {
+          if (fsSync.existsSync(filePath)) {
+            const relativePath = path.relative(this.projectRoot, filePath);
+            filesToBackup.push({
+              src: filePath,
+              dest: relativePath
+            });
+          }
+        }
+      }
+
+      // Add settings.json if it exists and has sessions hooks
+      const settingsInfo = this.installation.settingsHooks;
+      if (settingsInfo.exists && fsSync.existsSync(settingsInfo.file)) {
+        filesToBackup.push({
+          src: settingsInfo.file,
+          dest: '.claude/settings.json'
+        });
+      }
+
+      // Create tar.gz backup using the tar library
+      if (!tar) {
+        throw new Error('tar module not available - install with: npm install tar');
+      }
+
+      await tar.create(
+        {
+          gzip: true,
+          file: backupFile,
+          cwd: this.projectRoot
+        },
+        filesToBackup.map(f => f.dest)
+      );
+
+      // Create metadata file
+      const metadata = {
+        version: this.installation.version,
+        platform: this.platform,
+        date: new Date().toISOString(),
+        components: this.installation.components,
+        globalCommands: this.installation.globalCommands,
+        settingsHooks: this.installation.settingsHooks
+      };
+
+      await fs.writeFile(metadataFile, JSON.stringify(metadata, null, 2));
+
+      console.log(color(`✓ Backup created successfully: ${path.basename(backupFile)}`, colors.green));
+      return [true, backupFile];
+
+    } catch (e) {
+      console.log(color(`❌ Backup creation failed: ${e.message}`, colors.red));
+      return [false, e.message];
+    }
+  }
+
+  /**
+   * Show the main uninstaller menu
+   * @returns {Promise<string>} - User's menu choice
+   */
+  async showMainMenu() {
+    console.log();
+    console.log(color('╔══════════════════════════════════════════════════════════════╗', colors.bright + colors.cyan));
+    console.log(color('║              cc-sessions Safe Uninstaller                    ║', colors.bright + colors.cyan));
+    console.log(color('╚══════════════════════════════════════════════════════════════╝', colors.bright + colors.cyan));
+    console.log();
+
+    if (!this.installation) {
+      console.log(color('❌ No cc-sessions installation found in this directory', colors.red));
+      console.log(color('   Make sure you\'re in a project directory with cc-sessions installed', colors.dim));
+      return 'exit';
+    }
+
+    // Show installation summary
+    const totalComponents = Object.values(this.installation.components).reduce((sum, files) => sum + files.length, 0);
+    console.log(color(`  📦 Found cc-sessions v${this.installation.version} (${this.platform})`, colors.white));
+    console.log(color(`  📁 ${totalComponents} components detected`, colors.white));
+    console.log(color(`  🌐 ${this.installation.globalCommands.length} global commands`, colors.white));
+    console.log();
+
+    console.log(color('  What would you like to do?', colors.cyan));
+    console.log(color('  1. Complete Uninstall (safe - preserves user tasks)', colors.white));
+    console.log(color('  2. Selective Uninstall (choose components)', colors.yellow));
+    console.log(color('  3. Backup Only (create backup without removing)', colors.blue));
+    console.log(color('  4. Restore from Backup (restore previous installation)', colors.magenta));
+    console.log(color('  5. Dry Run (preview what would be removed)', colors.green));
+    console.log(color('  6. Exit (no changes)', colors.dim));
+    console.log();
+
+    while (true) {
+      const choice = await question(color('  Your choice (1-6): ', colors.cyan));
+      if (['1', '2', '3', '4', '5', '6'].includes(choice)) {
+        return {
+          '1': 'complete',
+          '2': 'selective',
+          '3': 'backup',
+          '4': 'restore',
+          '5': 'dry_run',
+          '6': 'exit'
+        }[choice];
+      }
+      console.log(color('  Please enter 1, 2, 3, 4, 5, or 6', colors.yellow));
+    }
+  }
+
+  /**
+   * Show what would be removed without actually removing anything
+   */
+  async performDryRun() {
+    console.log();
+    console.log(color('🔍 DRY RUN - Preview of what would be removed:', colors.bright + colors.green));
+    console.log(color('═'.repeat(60), colors.dim));
+
+    let totalFiles = 0;
+
+    for (const [category, files] of Object.entries(this.installation.components)) {
+      if (files.length > 0) {
+        console.log(color(`\n  ${category.toUpperCase()}:`, colors.cyan));
+        for (const filePath of files) {
+          console.log(color(`    - ${filePath}`, colors.white));
+          totalFiles++;
+        }
+      }
+    }
+
+    if (this.installation.globalCommands.length > 0) {
+      console.log(color('\n  GLOBAL COMMANDS:', colors.cyan));
+      for (const cmdPath of this.installation.globalCommands) {
+        console.log(color(`    - ${cmdPath}`, colors.white));
+        totalFiles++;
+      }
+    }
+
+    // Show settings.json changes
+    const settingsInfo = this.installation.settingsHooks;
+    if (settingsInfo.sessionsHooks && settingsInfo.sessionsHooks.length > 0) {
+      console.log(color('\n  SETTINGS.JSON HOOKS:', colors.cyan));
+      for (const hook of settingsInfo.sessionsHooks) {
+        console.log(color(`    - ${hook.type}: ${hook.command}`, colors.white));
+      }
+    }
+
+    // Show what would be preserved
+    console.log(color('\n  PRESERVED (will NOT be removed):', colors.green));
+    console.log(color('    - User tasks in sessions/tasks/ (except TEMPLATE.md)', colors.green));
+    console.log(color('    - Work logs and task content', colors.green));
+    console.log(color('    - CLAUDE.md and CLAUDE.sessions.md', colors.green));
+    console.log(color('    - Current task state (.claude/state/current_task.json)', colors.green));
+    console.log(color('    - Existing backups', colors.green));
+    console.log(color('    - Non-sessions settings in .claude/settings.json', colors.green));
+
+    console.log();
+    console.log(color(`📊 SUMMARY: ${totalFiles} files would be removed`, colors.bright + colors.yellow));
+    console.log(color('   User data and work would be preserved', colors.green));
+  }
+
+  /**
+   * Perform complete uninstall of cc-sessions
+   * @param {boolean} createBackup - Whether to create backup before removal
+   * @returns {Promise<boolean>} - Success status
+   */
+  async performCompleteUninstall(createBackupFlag = true) {
+    console.log();
+    console.log(color('🗑️  COMPLETE UNINSTALL', colors.bright + colors.red));
+    console.log(color('─'.repeat(30), colors.dim));
+
+    // Create backup if requested
+    if (createBackupFlag) {
+      if (!(await askYesNo('Create backup before uninstalling?', true))) {
+        if (!(await askYesNo('Are you sure you want to proceed without backup?', false))) {
+          console.log(color('  Uninstall cancelled', colors.yellow));
+          return false;
+        }
+      } else {
+        const [success, backupPath] = await this.createBackup();
+        if (!success) {
+          console.log(color(`  Backup failed: ${backupPath}`, colors.red));
+          if (!(await askYesNo('Continue uninstall without backup?', false))) {
+            return false;
+          }
+        }
+      }
+    }
+
+    // Final confirmation
+    console.log(color('\n⚠️  This will remove ALL cc-sessions components!', colors.bright + colors.red));
+    console.log(color('   User tasks and work logs will be preserved', colors.green));
+
+    if (!(await askYesNo('Proceed with complete uninstall?', false))) {
+      console.log(color('  Uninstall cancelled', colors.yellow));
+      return false;
+    }
+
+    try {
+      return await this.removeAllComponents();
+    } catch (e) {
+      console.log(color(`❌ Uninstall failed: ${e.message}`, colors.red));
+      return false;
+    }
+  }
+
+  /**
+   * Remove all cc-sessions components
+   * @returns {Promise<boolean>} - Success status
+   */
+  async removeAllComponents() {
+    console.log(color('\n🔄 Removing cc-sessions components...', colors.cyan));
+
+    let removedCount = 0;
+    let errorCount = 0;
+
+    // Remove component files
+    for (const [category, files] of Object.entries(this.installation.components)) {
+      if (files.length > 0) {
+        console.log(color(`  Removing ${category}...`, colors.dim));
+        for (const filePath of files) {
+          try {
+            const stats = await fs.stat(filePath);
+            if (stats.isDirectory()) {
+              await fs.rmdir(filePath, { recursive: true });
+            } else {
+              await fs.unlink(filePath);
+            }
+            removedCount++;
+          } catch (e) {
+            console.log(color(`    ⚠️  Could not remove ${filePath}: ${e.message}`, colors.yellow));
+            errorCount++;
+          }
+        }
+      }
+    }
+
+    // Remove global commands
+    if (this.installation.globalCommands.length > 0) {
+      console.log(color('  Removing global commands...', colors.dim));
+      for (const cmdPath of this.installation.globalCommands) {
+        try {
+          if (this.platform === 'macos' || this.platform === 'linux') {
+            if (cmdPath.startsWith('/usr/')) {
+              // May need sudo for Unix systems
+              execSync(`sudo rm "${cmdPath}"`, { stdio: 'inherit' });
+            } else {
+              await fs.unlink(cmdPath);
+            }
+          } else {
+            await fs.unlink(cmdPath);
+          }
+          removedCount++;
+        } catch (e) {
+          console.log(color(`    ⚠️  Could not remove ${cmdPath}: ${e.message}`, colors.yellow));
+          errorCount++;
+        }
+      }
+    }
+
+    // Clean up settings.json hooks
+    await this.removeSettingsHooks();
+
+    // Remove configuration file
+    try {
+      await fs.unlink(this.installation.configFile);
+      removedCount++;
+    } catch (e) {
+      console.log(color(`    ⚠️  Could not remove config file: ${e.message}`, colors.yellow));
+      errorCount++;
+    }
+
+    // Remove empty directories
+    await this.cleanupEmptyDirectories();
+
+    // Summary
+    console.log();
+    if (errorCount === 0) {
+      console.log(color('╔═══════════════════════════════════════════════╗', colors.bright + colors.green));
+      console.log(color('║           🎉 UNINSTALL COMPLETE! 🎉           ║', colors.bright + colors.green));
+      console.log(color('╚═══════════════════════════════════════════════╝', colors.bright + colors.green));
+    } else {
+      console.log(color('╔═══════════════════════════════════════════════╗', colors.bright + colors.yellow));
+      console.log(color('║         UNINSTALL COMPLETED WITH WARNINGS     ║', colors.bright + colors.yellow));
+      console.log(color('╚═══════════════════════════════════════════════╝', colors.bright + colors.yellow));
+    }
+
+    console.log();
+    console.log(color(`  ✓ ${removedCount} components removed`, colors.green));
+    if (errorCount > 0) {
+      console.log(color(`  ⚠️  ${errorCount} items had removal issues`, colors.yellow));
+    }
+    console.log(color('  ✓ User tasks and work preserved', colors.green));
+
+    return errorCount === 0;
+  }
+
+  /**
+   * Remove cc-sessions hooks from settings.json while preserving other settings
+   */
+  async removeSettingsHooks() {
+    const settingsInfo = this.installation.settingsHooks;
+    if (!settingsInfo.exists || settingsInfo.error) {
+      return;
+    }
+
+    try {
+      const settingsContent = await fs.readFile(settingsInfo.file, 'utf8');
+      const settings = JSON.parse(settingsContent);
+
+      // Remove cc-sessions hooks
+      if (settings.hooks) {
+        for (const hookType of Object.keys(settings.hooks)) {
+          if (settings.hooks[hookType]) {
+            // Filter out sessions hooks
+            const filteredConfigs = [];
+            for (const config of settings.hooks[hookType]) {
+              if (config.hooks) {
+                const filteredHooks = config.hooks.filter(hook => {
+                  const command = hook.command || '';
+                  return !['sessions-enforce.py', 'session-start.py', 'user-messages.py',
+                          'post-tool-use.py', 'task-completion-workflow.py',
+                          'post-implementation-retention.py', 'task-transcript-link.py']
+                    .some(sessionsHook => command.includes(sessionsHook));
+                });
+
+                if (filteredHooks.length > 0) {
+                  config.hooks = filteredHooks;
+                  filteredConfigs.push(config);
+                } else if (Object.keys(config).length > 1) {
+                  // Has other properties besides hooks
+                  delete config.hooks;
+                  filteredConfigs.push(config);
+                }
+              } else {
+                filteredConfigs.push(config);
+              }
+            }
+
+            if (filteredConfigs.length > 0) {
+              settings.hooks[hookType] = filteredConfigs;
+            } else {
+              delete settings.hooks[hookType];
+            }
+          }
+        }
+
+        // Remove hooks section if empty
+        if (Object.keys(settings.hooks).length === 0) {
+          delete settings.hooks;
+        }
+      }
+
+      // Remove statusline if it's sessions-related
+      if (settingsInfo.hasStatusline && settings.statusLine) {
+        if (settings.statusLine.command && settings.statusLine.command.includes('statusline-script.sh')) {
+          delete settings.statusLine;
+        }
+      }
+
+      // Save updated settings
+      await fs.writeFile(settingsInfo.file, JSON.stringify(settings, null, 2));
+      console.log(color('  ✓ Cleaned cc-sessions hooks from settings.json', colors.green));
+
+    } catch (e) {
+      console.log(color(`  ⚠️  Could not clean settings.json: ${e.message}`, colors.yellow));
+    }
+  }
+
+  /**
+   * Remove empty directories left behind after uninstall
+   */
+  async cleanupEmptyDirectories() {
+    const dirsToCheck = [
+      path.join(this.projectRoot, '.claude', 'hooks'),
+      path.join(this.projectRoot, '.claude', 'agents'),
+      path.join(this.projectRoot, '.claude', 'commands'),
+      path.join(this.projectRoot, 'sessions', 'protocols'),
+      path.join(this.projectRoot, 'sessions', 'knowledge', 'claude-code'),
+      path.join(this.projectRoot, 'sessions', 'knowledge')
+    ];
+
+    for (const dirPath of dirsToCheck) {
+      try {
+        const stats = await fs.stat(dirPath);
+        if (stats.isDirectory()) {
+          const files = await fs.readdir(dirPath);
+          if (files.length === 0) {
+            await fs.rmdir(dirPath);
+          }
+        }
+      } catch (e) {
+        // Directory doesn't exist or error accessing it, ignore
+      }
+    }
+  }
+
+  /**
+   * List available backups
+   * @returns {Promise<Array>} - List of [name, date, version] tuples
+   */
+  async listBackups() {
+    const backupDir = path.join(this.projectRoot, 'sessions', 'backups');
+
+    try {
+      const files = await fs.readdir(backupDir);
+      const backups = [];
+
+      for (const file of files) {
+        if (file.startsWith('cc-sessions-backup-') && file.endsWith('.tar.gz')) {
+          const metadataFile = path.join(backupDir, file.replace('.tar.gz', '.json'));
+          try {
+            const metadataContent = await fs.readFile(metadataFile, 'utf8');
+            const metadata = JSON.parse(metadataContent);
+
+            const name = file.replace('.tar.gz', '');
+            const date = metadata.date || 'unknown';
+            const version = metadata.version || 'unknown';
+            backups.push([name, date, version]);
+          } catch (e) {
+            // Skip backups without valid metadata
+          }
+        }
+      }
+
+      return backups.sort((a, b) => b[1].localeCompare(a[1])); // Sort by date, newest first
+    } catch (e) {
+      return [];
+    }
+  }
+
+  /**
+   * Run the main uninstaller interface
+   */
+  async run() {
+    console.log(color('╔════════════════════════════════════════════════════════════╗', colors.bright));
+    console.log(color('║              cc-sessions Safe Uninstaller                  ║', colors.bright));
+    console.log(color('╚════════════════════════════════════════════════════════════╝', colors.bright));
+    console.log();
+    console.log(color(`Platform: ${this.platform.toUpperCase()}`, colors.dim));
+    console.log(color(`Project: ${this.projectRoot}`, colors.dim));
+
+    // Detect installation
+    this.installation = await this.detectInstallation();
+
+    while (true) {
+      const choice = await this.showMainMenu();
+
+      if (choice === 'exit') {
+        console.log(color('\n  👋 No changes made. Exiting...', colors.cyan));
+        break;
+      } else if (choice === 'complete') {
+        await this.performCompleteUninstall();
+        break;
+      } else if (choice === 'selective') {
+        console.log(color('\n  📝 Selective uninstall not yet implemented', colors.yellow));
+        console.log(color('     Use complete uninstall for now', colors.dim));
+      } else if (choice === 'backup') {
+        const [success, backupPath] = await this.createBackup();
+        if (success) {
+          console.log(color(`  ✓ Backup created: ${backupPath}`, colors.green));
+        }
+      } else if (choice === 'restore') {
+        const backups = await this.listBackups();
+        if (backups.length === 0) {
+          console.log(color('\n  📂 No backups found', colors.yellow));
+        } else {
+          console.log(color('\n  📝 Restore functionality not yet implemented', colors.yellow));
+          console.log(color('     Available backups:', colors.dim));
+          for (const [name, date, version] of backups) {
+            console.log(color(`       - ${name} (v${version}, ${date.substring(0, 10)})`, colors.white));
+          }
+        }
+      } else if (choice === 'dry_run') {
+        await this.performDryRun();
+      }
+    }
+
+    rl.close();
+  }
+}
+
+/**
+ * Main entry point for the uninstaller
+ */
+async function main() {
+  try {
+    // Check if Python uninstaller is available and delegate to it
+    if (commandExists('python3') || commandExists('python')) {
+      const pythonCmd = commandExists('python3') ? 'python3' : 'python';
+
+      try {
+        // Try to run Python uninstaller if available
+        execSync(`${pythonCmd} -c "import cc_sessions.uninstall; cc_sessions.uninstall.main()"`,
+                { stdio: 'inherit' });
+        return;
+      } catch (e) {
+        // Python uninstaller not available, continue with JS version
+        console.log(color('Python uninstaller not available, using Node.js version...', colors.yellow));
+        console.log();
+      }
+    }
+
+    // Run JavaScript uninstaller
+    const uninstaller = new SessionsUninstaller();
+    await uninstaller.run();
+  } catch (e) {
+    if (e.message && e.message.includes('User force closed')) {
+      console.log(color('\n\n  Uninstaller interrupted by user', colors.yellow));
+      process.exit(1);
+    } else {
+      console.log(color(`\n❌ Uninstaller error: ${e.message}`, colors.red));
+      process.exit(1);
+    }
+  }
+}
+
+// Check if this script is being run directly
+if (require.main === module) {
+  main().catch(e => {
+    console.error(color(`Fatal error: ${e.message}`, colors.red));
+    process.exit(1);
+  });
+}
+
+module.exports = { SessionsUninstaller, main };


### PR DESCRIPTION
Fixes #30

Built this because manually cleaning up cc-sessions was becoming a pain, especially when you want to keep your actual work intact.

## What this does

Adds a proper uninstaller that:
- Works on Windows, Mac, Linux, and WSL
- Creates automatic backups before removing anything
- Actually preserves user tasks and work (because losing work sucks)
- Shows you what it's going to remove before doing it (dry-run mode)
- Cleans up settings.json without breaking other tools

## How to use it

After installing the update:
- Run `cc-sessions-uninstall` if you've got it globally installed
- Or `pipx run cc-sessions-uninstall` for Python folks
- Or `npx cc-sessions-uninstall` if you're on the Node.js side

## Testing

Tested the full cycle - install, uninstall, verify everything's gone except user data. The backup feature works, and it properly handles the global commands that need sudo.

The interactive menu gives you options for complete uninstall, selective removal, backup only, or just a dry run to see what would happen.

Let me know if you need any changes or find any edge cases I missed.