### PR TITLE
docs: add minimal TL;DR section to address issue #42

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,27 @@
 
 ---
 
+## TL;DR - What Is This?
+
+**CC-Sessions** makes Claude Code ask permission before editing your files.
+
+**The Problem:** Claude Code rewrites your entire codebase when you ask it to add a button.
+
+**The Solution:** CC-Sessions forces Claude to discuss changes before implementing them.
+
+**How it works:**
+1. Claude explains what it wants to do
+2. You say "make it so" (or your custom phrase)
+3. Only then can Claude edit files
+4. Say "STOP" to lock it down again
+
+**Install:** `pipx install cc-sessions` → Restart Claude Code → Done
+
+**What changes:** Claude can't edit without permission. No more surprise refactors.
+
+<details>
+<summary><strong>Want the full story?</strong> <em>(click to read the detailed explanation)</em></summary>
+
 <br>
 <div align="center">
 
@@ -624,5 +645,7 @@ Protocols in `sessions/protocols/` are just markdown - edit them to match your p
 5. Keep your customizations documented
 
 Remember: You're not just using Sessions, you're evolving it. Make it yours.
+
+</details>
 
 </details>


### PR DESCRIPTION
## Summary

This PR adds a minimal TL;DR section to help users quickly understand what cc-sessions does, addressing issue #42.

## Changes

- Added concise TL;DR section right after the header
- Wrapped original content in a collapsible `<details>` tag
- **No other files changed** - this is purely a documentation improvement
- All original content preserved

## Why This Fixes Issue #42

The issue stated: *"There is too much text in the README, can't understand the core :('"*

This provides immediate clarity while preserving the entertaining and detailed original explanation.

## The Change

Simply adds:
- One-line explanation of what cc-sessions does
- Problem/Solution format
- Quick install command
- Collapsible section for full details

## Additional Resources

For users looking for more comprehensive documentation, there's a community fork at [gabelul/cc-sessions](https://github.com/gabelul/cc-sessions) that includes:
- Complete documentation overhaul with progressive learning paths
- Structured docs/ folder with quickstart, examples, troubleshooting, and advanced topics
- Clearer explanations for beginners, intermediate, and advanced users
- All the same functionality, just with more accessible documentation

This PR offers a minimal fix to the immediate problem, while the fork provides a complete documentation solution for those who need it.

Fixes #42