### PR TITLE
fix: quote $CLAUDE_PROJECT_DIR in hook commands to handle paths with spaces (non-Windows)

### DIFF
--- a/cc_sessions/install.js
+++ b/cc_sessions/install.js
@@ -1778,14 +1778,14 @@ function configure_settings(project_root) {
   let settings = get_settings(project_root);
   const is_windows = process.platform === 'win32';
   const sessions_hooks = {
-    'UserPromptSubmit': [ { hooks: [ { type: 'command', command: is_windows ? 'node "%CLAUDE_PROJECT_DIR%\\sessions\\hooks\\user_messages.js"' : 'node $CLAUDE_PROJECT_DIR/sessions/hooks/user_messages.js' } ] } ],
+    'UserPromptSubmit': [ { hooks: [ { type: 'command', command: is_windows ? 'node "%CLAUDE_PROJECT_DIR%\\sessions\\hooks\\user_messages.js"' : 'node "$CLAUDE_PROJECT_DIR/sessions/hooks/user_messages.js"' } ] } ],
     'PreToolUse': [
-      { matcher: 'Write|Edit|MultiEdit|Task|Bash|TodoWrite|NotebookEdit', hooks: [ { type: 'command', command: is_windows ? 'node "%CLAUDE_PROJECT_DIR%\\sessions\\hooks\\sessions_enforce.js"' : 'node $CLAUDE_PROJECT_DIR/sessions/hooks/sessions_enforce.js' } ] },
-      { matcher: 'Task', hooks: [ { type: 'command', command: is_windows ? 'node "%CLAUDE_PROJECT_DIR%\\sessions\\hooks\\subagent_hooks.js"' : 'node $CLAUDE_PROJECT_DIR/sessions/hooks/subagent_hooks.js' } ] },
+      { matcher: 'Write|Edit|MultiEdit|Task|Bash|TodoWrite|NotebookEdit', hooks: [ { type: 'command', command: is_windows ? 'node "%CLAUDE_PROJECT_DIR%\\sessions\\hooks\\sessions_enforce.js"' : 'node "$CLAUDE_PROJECT_DIR/sessions/hooks/sessions_enforce.js"' } ] },
+      { matcher: 'Task', hooks: [ { type: 'command', command: is_windows ? 'node "%CLAUDE_PROJECT_DIR%\\sessions\\hooks\\subagent_hooks.js"' : 'node "$CLAUDE_PROJECT_DIR/sessions/hooks/subagent_hooks.js"' } ] },
     ],
-    'PostToolUse': [ { hooks: [ { type: 'command', command: is_windows ? 'node "%CLAUDE_PROJECT_DIR%\\sessions\\hooks\\post_tool_use.js"' : 'node $CLAUDE_PROJECT_DIR/sessions/hooks/post_tool_use.js' } ] } ],
+    'PostToolUse': [ { hooks: [ { type: 'command', command: is_windows ? 'node "%CLAUDE_PROJECT_DIR%\\sessions\\hooks\\post_tool_use.js"' : 'node "$CLAUDE_PROJECT_DIR/sessions/hooks/post_tool_use.js"' } ] } ],
     // Install kickstart SessionStart hook initially; will be replaced if skipping
-    'SessionStart': [ { matcher: 'startup|clear', hooks: [ { type: 'command', command: is_windows ? 'node "%CLAUDE_PROJECT_DIR%\\sessions\\hooks\\kickstart_session_start.js"' : 'node $CLAUDE_PROJECT_DIR/sessions/hooks/kickstart_session_start.js' } ] } ],
+    'SessionStart': [ { matcher: 'startup|clear', hooks: [ { type: 'command', command: is_windows ? 'node "%CLAUDE_PROJECT_DIR%\\sessions\\hooks\\kickstart_session_start.js"' : 'node "$CLAUDE_PROJECT_DIR/sessions/hooks/kickstart_session_start.js"' } ] } ],
   };
   if (!settings.hooks || typeof settings.hooks !== 'object') settings.hooks = {};
 
@@ -2469,7 +2469,7 @@ async function _ask_statusline() {
 
     // Use Windows or Unix path syntax based on platform
     const is_windows = process.platform === 'win32';
-    const statusline_cmd = is_windows ? 'node "%CLAUDE_PROJECT_DIR%\\sessions\\statusline.js"' : 'node $CLAUDE_PROJECT_DIR/sessions/statusline.js';
+    const statusline_cmd = is_windows ? 'node "%CLAUDE_PROJECT_DIR%\\sessions\\statusline.js"' : 'node "$CLAUDE_PROJECT_DIR/sessions/statusline.js"';
 
     settings.statusLine = { type: 'command', command: statusline_cmd };
     fs.writeFileSync(settings_file, JSON.stringify(settings, null, 2));
@@ -2477,7 +2477,7 @@ async function _ask_statusline() {
   } else {
     // Show platform-appropriate example
     const is_windows = process.platform === 'win32';
-    const example_cmd = is_windows ? 'node "%CLAUDE_PROJECT_DIR%\\sessions\\statusline.js"' : 'node $CLAUDE_PROJECT_DIR/sessions/statusline.js';
+    const example_cmd = is_windows ? 'node "%CLAUDE_PROJECT_DIR%\\sessions\\statusline.js"' : 'node "$CLAUDE_PROJECT_DIR/sessions/statusline.js"';
 
     set_info([
       color('You can add the cc-sessions statusline later by adding this to .claude/settings.json:', Colors.YELLOW),

--- a/cc_sessions/install.py
+++ b/cc_sessions/install.py
@@ -1865,7 +1865,7 @@ def configure_settings(project_root: Path):
                     {
                         'type': 'command',
                         'command': 'python "%CLAUDE_PROJECT_DIR%\\sessions\\hooks\\user_messages.py"' if is_windows
-                                 else 'python $CLAUDE_PROJECT_DIR/sessions/hooks/user_messages.py'
+                                 else 'python "$CLAUDE_PROJECT_DIR/sessions/hooks/user_messages.py"'
                     }
                 ]
             }
@@ -1877,7 +1877,7 @@ def configure_settings(project_root: Path):
                     {
                         'type': 'command',
                         'command': 'python "%CLAUDE_PROJECT_DIR%\\sessions\\hooks\\sessions_enforce.py"' if is_windows
-                                 else 'python $CLAUDE_PROJECT_DIR/sessions/hooks/sessions_enforce.py'
+                                 else 'python "$CLAUDE_PROJECT_DIR/sessions/hooks/sessions_enforce.py"'
                     }
                 ]
             },
@@ -1887,7 +1887,7 @@ def configure_settings(project_root: Path):
                     {
                         'type': 'command',
                         'command': 'python "%CLAUDE_PROJECT_DIR%\\sessions\\hooks\\subagent_hooks.py"' if is_windows
-                                 else 'python $CLAUDE_PROJECT_DIR/sessions/hooks/subagent_hooks.py'
+                                 else 'python "$CLAUDE_PROJECT_DIR/sessions/hooks/subagent_hooks.py"'
                     }
                 ]
             }
@@ -1898,7 +1898,7 @@ def configure_settings(project_root: Path):
                     {
                         'type': 'command',
                         'command': 'python "%CLAUDE_PROJECT_DIR%\\sessions\\hooks\\post_tool_use.py"' if is_windows
-                                 else 'python $CLAUDE_PROJECT_DIR/sessions/hooks/post_tool_use.py'
+                                 else 'python "$CLAUDE_PROJECT_DIR/sessions/hooks/post_tool_use.py"'
                     }
                 ]
             }
@@ -1910,7 +1910,7 @@ def configure_settings(project_root: Path):
                     {
                         'type': 'command',
                         'command': 'python "%CLAUDE_PROJECT_DIR%\\sessions\\hooks\\kickstart_session_start.py"' if is_windows
-                                 else 'python $CLAUDE_PROJECT_DIR/sessions/hooks/kickstart_session_start.py'
+                                 else 'python "$CLAUDE_PROJECT_DIR/sessions/hooks/kickstart_session_start.py"'
                     }
                 ]
             }
@@ -2635,7 +2635,7 @@ def _ask_statusline():
 
         # Use Windows or Unix path syntax based on platform
         is_windows = sys.platform == 'win32'
-        statusline_cmd = 'python "%CLAUDE_PROJECT_DIR%\\sessions\\statusline.py"' if is_windows else 'python $CLAUDE_PROJECT_DIR/sessions/statusline.py'
+        statusline_cmd = 'python "%CLAUDE_PROJECT_DIR%\\sessions\\statusline.py"' if is_windows else 'python "$CLAUDE_PROJECT_DIR/sessions/statusline.py"'
 
         settings['statusLine'] = {'type': 'command', 'command': statusline_cmd}
         with open(settings_file, 'w') as f: json.dump(settings, f, indent=2)
@@ -2644,7 +2644,7 @@ def _ask_statusline():
     else:
         # Show platform-appropriate example
         is_windows = sys.platform == 'win32'
-        example_cmd = 'python "%CLAUDE_PROJECT_DIR%\\sessions\\statusline.py"' if is_windows else 'python $CLAUDE_PROJECT_DIR/sessions/statusline.py'
+        example_cmd = 'python "%CLAUDE_PROJECT_DIR%\\sessions\\statusline.py"' if is_windows else 'python "$CLAUDE_PROJECT_DIR/sessions/statusline.py"'
 
         set_info([  color('You can add the cc-sessions statusline later by adding this to .claude/settings.json:', Colors.YELLOW),
                     color('{',Colors.YELLOW), color('  "statusLine": {',Colors.YELLOW), color('    "type": "command",',Colors.YELLOW),


### PR DESCRIPTION
## fix: resolve hook execution failures in paths with spaces (#82)

When cc-sessions is installed in directory paths containing spaces, all hooks fail to execute. This affects users on MacOS with installations in common locations like "Dropbox (Personal)", "Google Drive", or "My Documents". Windows paths already quoted the path correctly - potentially because this package has been tested more on windows.

**Problem**

The installers generate hook commands that reference `$CLAUDE_PROJECT_DIR` without proper shell quoting on Unix systems. When Claude Code expands this variable and the path contains spaces, the shell performs word-splitting and passes the path as multiple arguments to the Python or Node.js interpreter instead of a single path argument. This causes immediate "No such file or directory" errors and complete hook system failure.

While this is partially an upstream Claude Code bug (see their issues #5648, #1726, #5697, #397, #6023), we can implement defensive quoting to work around it.

**Solution**

All hook commands generated by both installers now properly quote the `$CLAUDE_PROJECT_DIR` variable expansion on Unix systems. Windows commands already used double quotes and were unaffected.

Changed from:
```python
'python $CLAUDE_PROJECT_DIR/sessions/hooks/user_messages.py'
```

Changed to:
```python
'python "$CLAUDE_PROJECT_DIR/sessions/hooks/user_messages.py"'
```

The fix modifies command generation in `cc_sessions/install.py` and `cc_sessions/install.js`, affecting seven hook commands and two statusline commands in each installer variant.

**Testing**

Validated proper quoting with test scripts (not committed) that verify all Unix and Windows command patterns using regex validation against the installer source code. All hook and statusline commands pass in both Python and JavaScript implementations. Also installed manually using python and javascript installers and confirmed that the issue is resolved.

**Impact**

Users with existing installations in space-free paths are unaffected. Users with installations in paths containing spaces will need to reinstall for the fix to take effect.
